### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/odluser676710/eba467ca-1a98-44ea-a008-ff4735b0f0a5/26f5967f-0e30-4e9f-a02b-8240eebafe1d/_apis/work/boardbadge/67a932e8-1c39-4dd6-b034-0b890328440c)](https://dev.azure.com/odluser676710/eba467ca-1a98-44ea-a008-ff4735b0f0a5/_boards/board/t/26f5967f-0e30-4e9f-a02b-8240eebafe1d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/odluser676710/eba467ca-1a98-44ea-a008-ff4735b0f0a5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.